### PR TITLE
Adds ability to compile against Net Framework 4.6

### DIFF
--- a/Jsbeautifier/Jsbeautifier.csproj
+++ b/Jsbeautifier/Jsbeautifier.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard2.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">netstandard2.0;net46</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
This is a small change. I still use Net Framework 4.6 (in PowerShell 5.1) therefore I need a proper dll. Hope it's useful to you as well. 